### PR TITLE
⬆ Sync with new mbed targets api

### DIFF
--- a/mbed_devices/mbed_devices.py
+++ b/mbed_devices/mbed_devices.py
@@ -1,6 +1,6 @@
 """API for listing devices."""
 from typing import Iterable, Optional
-from mbed_targets import MbedTarget, get_target
+from mbed_targets import MbedTarget, get_target_by_product_code
 from mbed_tools_lib.exceptions import ToolsError
 
 from mbed_devices.device import Device
@@ -30,6 +30,6 @@ def _get_mbed_target_for_candidate(candidate: CandidateDevice) -> Optional[MbedT
         return None
 
     try:
-        return get_target(product_code)
+        return get_target_by_product_code(product_code)
     except ToolsError:
         return None

--- a/news/20200304.feature
+++ b/news/20200304.feature
@@ -1,0 +1,1 @@
+Use new public api of mbed-targets

--- a/tests/test_mbed_devices.py
+++ b/tests/test_mbed_devices.py
@@ -38,25 +38,25 @@ class TestBuildDevice(TestCase):
 
 
 class TestGetMbedTargetForCandidate(TestCase):
-    @mock.patch("mbed_devices.mbed_devices.get_target")
+    @mock.patch("mbed_devices.mbed_devices.get_target_by_product_code")
     @mock.patch("mbed_devices.mbed_devices.extract_product_code")
-    def test_uses_product_code_to_fetch_target(self, extract_product_code, get_target):
+    def test_uses_product_code_to_fetch_target(self, extract_product_code, get_target_by_product_code):
         candidate = CandidateDeviceFactory()
-        self.assertEqual(_get_mbed_target_for_candidate(candidate), get_target.return_value)
+        self.assertEqual(_get_mbed_target_for_candidate(candidate), get_target_by_product_code.return_value)
         extract_product_code.assert_called_once_with(candidate)
-        get_target.assert_called_once_with(extract_product_code.return_value)
+        get_target_by_product_code.assert_called_once_with(extract_product_code.return_value)
 
-    @mock.patch("mbed_devices.mbed_devices.get_target")
+    @mock.patch("mbed_devices.mbed_devices.get_target_by_product_code")
     @mock.patch("mbed_devices.mbed_devices.extract_product_code")
-    def test_returns_none_when_product_code_cannot_be_extracted(self, extract_product_code, get_target):
+    def test_returns_none_when_product_code_cannot_be_extracted(self, extract_product_code, get_target_by_product_code):
         candidate = CandidateDeviceFactory()
         extract_product_code.side_effect = MissingProductCode
         self.assertIsNone(_get_mbed_target_for_candidate(candidate))
-        get_target.assert_not_called()
+        get_target_by_product_code.assert_not_called()
 
-    @mock.patch("mbed_devices.mbed_devices.get_target")
+    @mock.patch("mbed_devices.mbed_devices.get_target_by_product_code")
     @mock.patch("mbed_devices.mbed_devices.extract_product_code")
-    def test_returns_none_when_target_not_found(self, extract_product_code, get_target):
+    def test_returns_none_when_target_not_found(self, extract_product_code, get_target_by_product_code):
         candidate = CandidateDeviceFactory()
-        get_target.side_effect = ToolsError
+        get_target_by_product_code.side_effect = ToolsError
         self.assertIsNone(_get_mbed_target_for_candidate(candidate))


### PR DESCRIPTION
### Description

`get_target` -> `get_target_by_product_code`


### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
