### PR TITLE
✨ Expose targets db mode in the public api

### DIFF
--- a/mbed_devices/_internal/resolve_target.py
+++ b/mbed_devices/_internal/resolve_target.py
@@ -23,12 +23,8 @@ def resolve_target(candidate: CandidateDevice) -> MbedTarget:
     The specification of those HTM files is that they redirect to devices product page on os.mbed.com.
     Information about Mbed Enabled requirements: https://www.mbed.com/en/about-mbed/mbed-enabled/requirements/
     """
-    return _resolve_target_using_file_contents(_get_all_htm_files_contents(candidate.mount_points))
-
-
-def _resolve_target_using_file_contents(all_files_contents: Iterable[str]) -> MbedTarget:
     try:
-        target_resolver = _build_target_resolver(all_files_contents)
+        target_resolver = _build_target_resolver(candidate)
     except UnableToBuildResolver:
         raise NoTargetForCandidate
 
@@ -42,7 +38,8 @@ class UnableToBuildResolver(Exception):
     """Raised when theres not enough information on the candidate to build a target resolver."""
 
 
-def _build_target_resolver(all_files_contents: Iterable[str]) -> Callable:
+def _build_target_resolver(candidate: CandidateDevice) -> Callable:
+    all_files_contents = _get_all_htm_files_contents(candidate.mount_points)
     try:
         product_code = _extract_product_code(all_files_contents)
         return functools.partial(get_target_by_product_code, product_code)

--- a/mbed_devices/_internal/resolve_target.py
+++ b/mbed_devices/_internal/resolve_target.py
@@ -6,7 +6,7 @@ import functools
 import itertools
 import pathlib
 from typing import Callable, Iterable, List
-from mbed_targets import MbedTarget, UnknownTarget, get_target_by_product_code, get_target_by_online_id
+from mbed_targets import DatabaseMode, MbedTarget, UnknownTarget, get_target_by_online_id, get_target_by_product_code
 
 from mbed_devices._internal.htm_file import OnlineId, read_online_id, read_product_code
 from mbed_devices._internal.candidate_device import CandidateDevice
@@ -16,7 +16,7 @@ class NoTargetForCandidate(Exception):
     """Raised when target cannot be determined for a candidate."""
 
 
-def resolve_target(candidate: CandidateDevice) -> MbedTarget:
+def resolve_target(candidate: CandidateDevice, mode: DatabaseMode = DatabaseMode.AUTO) -> MbedTarget:
     """Resolves target for given CandidateDevice if possible.
 
     Currently, the mechanism for resolving targets relies on existence of HTM files in devices mass storage.
@@ -29,7 +29,7 @@ def resolve_target(candidate: CandidateDevice) -> MbedTarget:
         raise NoTargetForCandidate
 
     try:
-        return target_resolver()
+        return target_resolver(mode=mode)
     except UnknownTarget:
         raise NoTargetForCandidate
 

--- a/mbed_devices/mbed_devices.py
+++ b/mbed_devices/mbed_devices.py
@@ -2,26 +2,25 @@
 from typing import Iterable
 
 from mbed_devices.device import Device
-from mbed_devices._internal.candidate_device import CandidateDevice
 from mbed_devices._internal.detect_candidate_devices import detect_candidate_devices
 from mbed_devices._internal.resolve_target import resolve_target, NoTargetForCandidate
+from mbed_targets import DatabaseMode
 
 
-def get_connected_devices() -> Iterable[Device]:
+def get_connected_devices(mode: DatabaseMode = DatabaseMode.AUTO) -> Iterable[Device]:
     """Returns Mbed Devices connected to host computer."""
     devices = []
-    for candidate_device in detect_candidate_devices():
+    for candidate in detect_candidate_devices():
         try:
-            devices.append(_build_device(candidate_device))
+            target = resolve_target(candidate=candidate, mode=mode)
+            devices.append(
+                Device(
+                    serial_port=candidate.serial_port,
+                    serial_number=candidate.serial_number,
+                    mount_points=candidate.mount_points,
+                    mbed_target=target,
+                )
+            )
         except NoTargetForCandidate:
             pass
     return devices
-
-
-def _build_device(candidate: CandidateDevice) -> Device:
-    return Device(
-        serial_port=candidate.serial_port,
-        serial_number=candidate.serial_number,
-        mount_points=candidate.mount_points,
-        mbed_target=resolve_target(candidate),
-    )

--- a/news/20200310.feature
+++ b/news/20200310.feature
@@ -1,0 +1,1 @@
+Ability to set DatabaseMode in public api

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -6,85 +6,97 @@ from mbed_targets import UnknownTarget
 from tests.factories import CandidateDeviceFactory
 from mbed_devices._internal.htm_file import OnlineId
 from mbed_devices._internal.resolve_target import (
+    UnableToBuildResolver,
     NoTargetForCandidate,
-    _resolve_target_using_file_contents,
+    _get_all_htm_files_contents,
     resolve_target,
+    _build_target_resolver,
 )
 
 
+@mock.patch("mbed_devices._internal.resolve_target._build_target_resolver")
 class TestResolveTarget(TestCase):
-    @mock.patch("mbed_devices._internal.resolve_target._resolve_target_using_file_contents")
-    def test_resolves_target_using_htm_file_contents_found_in_mount_points(self, _resolve_target_using_file_contents):
-        files = [(pathlib.Path("/test-1/mbed.htm"), "foo"), (pathlib.Path("/test-2/whatever.htm"), "bar")]
-        with Patcher() as patcher:
-            for (path, contents) in files:
-                patcher.fs.create_file(str(path), contents=contents)
-            patcher.fs.create_file("/test-1/._MBED.HTM", contents="hello")
-            patcher.fs.create_file("/test-1/file.txt", contents="whatever")
+    def test_returns_target_resolved_using_built_target_resolver(self, _build_target_resolver):
+        candidate = CandidateDeviceFactory()
 
-            result = resolve_target(
-                CandidateDeviceFactory(mount_points=[pathlib.Path("/test-1"), pathlib.Path("/test-2")])
-            )
+        subject = resolve_target(candidate)
 
-        self.assertEqual(result, _resolve_target_using_file_contents.return_value)
-        _resolve_target_using_file_contents.assert_called_once_with(["foo", "bar"])
+        self.assertEqual(subject, _build_target_resolver.return_value.return_value)
+        _build_target_resolver.assert_called_once_with(candidate)
 
-
-class TestResolveTargetUsingFileContents(TestCase):
-    @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
-    @mock.patch("mbed_devices._internal.resolve_target.get_target_by_product_code")
-    def test_resolves_targets_using_product_code_when_available(self, get_target_by_product_code, read_product_code):
-        read_product_code.return_value = "0123"
-
-        self.assertEqual(
-            _resolve_target_using_file_contents(["file contents"]), get_target_by_product_code.return_value
-        )
-        get_target_by_product_code.assert_called_once_with(read_product_code.return_value)
-        read_product_code.assert_called_once_with("file contents")
-
-    @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
-    @mock.patch("mbed_devices._internal.resolve_target.get_target_by_product_code")
-    def test_raises_when_resolving_using_product_code_fails(self, get_target_by_product_code, read_product_code):
-        read_product_code.return_value = "1234"
-        get_target_by_product_code.side_effect = UnknownTarget
+    def test_raises_when_resolver_cannot_be_built(self, _build_target_resolver):
+        _build_target_resolver.side_effect = UnableToBuildResolver
+        candidate = CandidateDeviceFactory()
 
         with self.assertRaises(NoTargetForCandidate):
-            _resolve_target_using_file_contents(["some file contents"])
+            resolve_target(candidate)
+
+    def test_raises_when_target_cannot_be_resolved(self, _build_target_resolver):
+        resolver = mock.Mock(side_effect=UnknownTarget)
+        _build_target_resolver.return_value = resolver
+        candidate = CandidateDeviceFactory()
+
+        with self.assertRaises(NoTargetForCandidate):
+            resolve_target(candidate)
+
+
+@mock.patch("mbed_devices._internal.resolve_target._get_all_htm_files_contents")
+class TestBuildTargetResolver(TestCase):
+    @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
+    @mock.patch("mbed_devices._internal.resolve_target.get_target_by_product_code")
+    def test_will_resolve_targets_using_product_code_when_available(
+        self, get_target_by_product_code, read_product_code, _get_all_htm_files_contents
+    ):
+        _get_all_htm_files_contents.return_value = ["file contents"]
+        read_product_code.return_value = "0123"
+        candidate = CandidateDeviceFactory()
+
+        subject = _build_target_resolver(candidate)()
+
+        self.assertEqual(subject, get_target_by_product_code.return_value)
+        get_target_by_product_code.assert_called_once_with(read_product_code.return_value)
+        read_product_code.assert_called_once_with("file contents")
+        _get_all_htm_files_contents.assert_called_once_with(candidate.mount_points)
 
     @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
     @mock.patch("mbed_devices._internal.resolve_target.read_online_id")
     @mock.patch("mbed_devices._internal.resolve_target.get_target_by_online_id")
-    def test_resolves_targets_using_online_id_when_available(
-        self, get_target_by_online_id, read_online_id, read_product_code
+    def test_will_resolve_targets_using_online_id_when_available(
+        self, get_target_by_online_id, read_online_id, read_product_code, _get_all_htm_files_contents
     ):
+        _get_all_htm_files_contents.return_value = ["some file contents"]
         online_id = OnlineId(device_type="hat", device_slug="boat")
         read_product_code.return_value = None
         read_online_id.return_value = online_id
+        candidate = CandidateDeviceFactory()
 
-        self.assertEqual(
-            _resolve_target_using_file_contents(["some file contents"]), get_target_by_online_id.return_value
-        )
+        subject = _build_target_resolver(candidate)()
+
+        self.assertEqual(subject, get_target_by_online_id.return_value)
         read_online_id.assert_called_with("some file contents")
         get_target_by_online_id.assert_called_once_with(slug=online_id.device_slug, target_type=online_id.device_type)
 
     @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
     @mock.patch("mbed_devices._internal.resolve_target.read_online_id")
-    @mock.patch("mbed_devices._internal.resolve_target.get_target_by_online_id")
-    def test_raises_when_resolving_using_online_id_fails(
-        self, get_target_by_online_id, read_online_id, read_product_code
+    def test_raises_when_no_information_found_on_candidate(
+        self, read_product_code, read_online_id, _get_all_htm_files_contents
     ):
-        read_product_code.return_value = None
-        read_online_id.return_value = OnlineId(device_type="hat", device_slug="boat")
-        get_target_by_online_id.side_effect = UnknownTarget
-
-        with self.assertRaises(NoTargetForCandidate):
-            _resolve_target_using_file_contents(["whatever"])
-
-    @mock.patch("mbed_devices._internal.resolve_target.read_product_code")
-    @mock.patch("mbed_devices._internal.resolve_target.read_online_id")
-    def test_raises_when_no_information_found_on_candidate(self, read_product_code, read_online_id):
+        _get_all_htm_files_contents.return_value = ["foo"]
         read_product_code.return_value = None
         read_online_id.return_value = None
 
-        with self.assertRaises(NoTargetForCandidate):
-            _resolve_target_using_file_contents(["zero information in this file"])
+        with self.assertRaises(UnableToBuildResolver):
+            _build_target_resolver(CandidateDeviceFactory())()
+
+
+class TestGetAllHtmFilesContents(TestCase):
+    def test_returns_contents_of_all_htm_files_in_given_directories(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file("/test-1/mbed.htm", contents="foo")
+            patcher.fs.create_file("/test-2/whatever.htm", contents="bar")
+            patcher.fs.create_file("/test-1/file.txt", contents="txt files should not be read")
+            patcher.fs.create_file("/test-1/._MBED.HTM", contents="hidden files should not be read")
+
+            result = _get_all_htm_files_contents([pathlib.Path("/test-1"), pathlib.Path("/test-2")])
+
+        self.assertEqual(result, ["foo", "bar"])

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -1,16 +1,16 @@
 import pathlib
 from pyfakefs.fake_filesystem_unittest import Patcher
 from unittest import TestCase, mock
-from mbed_targets import UnknownTarget
+from mbed_targets import UnknownTarget, DatabaseMode
 
 from tests.factories import CandidateDeviceFactory
 from mbed_devices._internal.htm_file import OnlineId
 from mbed_devices._internal.resolve_target import (
-    UnableToBuildResolver,
     NoTargetForCandidate,
+    UnableToBuildResolver,
+    _build_target_resolver,
     _get_all_htm_files_contents,
     resolve_target,
-    _build_target_resolver,
 )
 
 
@@ -38,6 +38,15 @@ class TestResolveTarget(TestCase):
 
         with self.assertRaises(NoTargetForCandidate):
             resolve_target(candidate)
+
+    def test_uses_given_database_mode_to_resolve_targets(self, _build_target_resolver):
+        mode = DatabaseMode.ONLINE
+        resolver = mock.Mock()
+        _build_target_resolver.return_value = resolver
+
+        resolve_target(CandidateDeviceFactory(), mode)
+
+        resolver.assert_called_once_with(mode=mode)
 
 
 @mock.patch("mbed_devices._internal.resolve_target._get_all_htm_files_contents")

--- a/tests/test_mbed_devices.py
+++ b/tests/test_mbed_devices.py
@@ -4,6 +4,7 @@ from tests.factories import CandidateDeviceFactory
 from mbed_devices.device import Device
 from mbed_devices._internal.resolve_target import NoTargetForCandidate
 from mbed_devices.mbed_devices import get_connected_devices
+from mbed_targets import DatabaseMode
 
 
 class TestGetConnectedDevices(TestCase):
@@ -11,9 +12,10 @@ class TestGetConnectedDevices(TestCase):
     @mock.patch("mbed_devices.mbed_devices.resolve_target")
     def test_builds_devices_from_candidates(self, resolve_target, detect_candidate_devices):
         candidate = CandidateDeviceFactory()
+        mode = DatabaseMode.ONLINE
         detect_candidate_devices.return_value = [candidate]
         self.assertEqual(
-            get_connected_devices(),
+            get_connected_devices(mode),
             [
                 Device(
                     serial_port=candidate.serial_port,
@@ -23,7 +25,7 @@ class TestGetConnectedDevices(TestCase):
                 )
             ],
         )
-        resolve_target.assert_called_once_with(candidate)
+        resolve_target.assert_called_once_with(candidate=candidate, mode=mode)
 
     @mock.patch("mbed_devices.mbed_devices.detect_candidate_devices")
     @mock.patch("mbed_devices.mbed_devices.resolve_target")


### PR DESCRIPTION
### Description

Allow setting the mode to use in `mbed-targets` in the public api. Separate PR with cli params will follow.

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
