### PR TITLE
✨ Proxy expose config variables from mbed-targets

### DIFF
--- a/mbed_devices/mbed_tools.py
+++ b/mbed_devices/mbed_tools.py
@@ -1,4 +1,6 @@
 """Integration with https://github.com/ARMmbed/mbed-tools."""
 from mbed_devices._internal.mbed_tools.list_connected_devices import list_connected_devices
+from mbed_targets.mbed_tools.config_variables import config_variables as mbed_targets_config_variables
 
 cli = list_connected_devices
+config_variables = mbed_targets_config_variables

--- a/mbed_devices/mbed_tools.py
+++ b/mbed_devices/mbed_tools.py
@@ -1,6 +1,6 @@
 """Integration with https://github.com/ARMmbed/mbed-tools."""
 from mbed_devices._internal.mbed_tools.list_connected_devices import list_connected_devices
-from mbed_targets.mbed_tools.config_variables import config_variables as mbed_targets_config_variables
+from mbed_targets.mbed_tools import config_variables as mbed_targets_config_variables
 
 cli = list_connected_devices
 config_variables = mbed_targets_config_variables

--- a/news/20200317.feature
+++ b/news/20200317.feature
@@ -1,0 +1,1 @@
+Expose configuration variables to the cli

--- a/tests/test_mbed_tools.py
+++ b/tests/test_mbed_tools.py
@@ -1,9 +1,15 @@
 from unittest import TestCase
+from mbed_targets.mbed_tools import config_variables as mbed_targets_config_variables
 
-from mbed_devices.mbed_tools import cli
+from mbed_devices.mbed_tools import cli, config_variables
 from mbed_devices._internal.mbed_tools.list_connected_devices import list_connected_devices
 
 
 class TestCli(TestCase):
     def test_aliases_list_connected_devices(self):
         self.assertEqual(cli, list_connected_devices)
+
+
+class TestConfigVariables(TestCase):
+    def test_aliases_list_of_config_variables_from_mbed_targets(self):
+        self.assertEqual(config_variables, mbed_targets_config_variables)


### PR DESCRIPTION
### Description

`mbed-devices` has no config variables of it's own, but it uses `mbed-targets`.

Relies on https://github.com/ARMmbed/mbed-targets/pull/109 being released.

Output from `mbed-tools`. Note that output format is not set in stone yet - just proof it works.
<img width="940" alt="Screenshot 2020-03-17 at 14 37 02" src="https://user-images.githubusercontent.com/454838/76866988-cafbc900-685c-11ea-8e3c-edf40fbce67e.png">

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
