### PR TITLE
✨ New command line option `--show-all` to display all connected devices and improved log messages

### DIFF
--- a/mbed_devices/_internal/htm_file.py
+++ b/mbed_devices/_internal/htm_file.py
@@ -93,9 +93,9 @@ def read_product_code(file_contents: str) -> Optional[str]:
 def read_online_id(file_contents: str) -> Optional[OnlineId]:
     """Returns online id parsed from the files contents, None if not found."""
     regex = r"""
-            (?P<target_type>module|platform)s  # module|platform
-            \/                                 # forward slash in the url
-            (?P<slug>[-\w]+)            # permitted characters in a slug are letters and digits
+            (?P<target_type>module|platform)s   # module|platform
+            \/                                  # forward slash in the url
+            (?P<slug>[-\w]+)                    # permitted characters in a slug are letters and digits
     """
     match = re.search(regex, file_contents, re.VERBOSE)
     if match:

--- a/mbed_devices/_internal/htm_file.py
+++ b/mbed_devices/_internal/htm_file.py
@@ -69,11 +69,13 @@ from typing import Optional, NamedTuple
 class OnlineId(NamedTuple):
     """Used to identify the target against the os.mbed.com website.
 
-    OnlineId(device_type="platform", slug="SOME-SLUG") -> https://os.mbed.com/platforms/SOME-SLUG
+    The target type and slug are used in the URI for the board and together they can be used uniquely identify a board.
+
+    OnlineId(target_type="platform", slug="SOME-SLUG") -> https://os.mbed.com/platforms/SOME-SLUG
     """
 
-    device_type: str
-    device_slug: str
+    target_type: str
+    slug: str
 
 
 def read_product_code(file_contents: str) -> Optional[str]:
@@ -91,11 +93,11 @@ def read_product_code(file_contents: str) -> Optional[str]:
 def read_online_id(file_contents: str) -> Optional[OnlineId]:
     """Returns online id parsed from the files contents, None if not found."""
     regex = r"""
-            (?P<device_type>module|platform)s  # module|platform
+            (?P<target_type>module|platform)s  # module|platform
             \/                                 # forward slash in the url
-            (?P<device_slug>[-\w]+)            # permitted characters in a slug are letters and digits
+            (?P<slug>[-\w]+)            # permitted characters in a slug are letters and digits
     """
     match = re.search(regex, file_contents, re.VERBOSE)
     if match:
-        return OnlineId(device_type=match["device_type"], device_slug=match["device_slug"])
+        return OnlineId(target_type=match["target_type"], slug=match["slug"])
     return None

--- a/mbed_devices/_internal/mbed_tools/list_connected_devices.py
+++ b/mbed_devices/_internal/mbed_tools/list_connected_devices.py
@@ -24,14 +24,14 @@ from mbed_targets import MbedTarget
     default=False,
     help="Show all connected devices, even those which are not Mbed Targets.",
 )
-def list_connected_devices(format: str, show_all: str) -> None:
+def list_connected_devices(format: str, show_all: bool) -> None:
     """Prints connected devices."""
-    identified_devices, unidentified_devices = get_connected_devices()
+    connected_devices = get_connected_devices()
 
     if show_all:
-        devices = _sort_devices_by_name(identified_devices + unidentified_devices)
+        devices = _sort_devices_by_name(connected_devices.identified_devices + connected_devices.unidentified_devices)
     else:
-        devices = _sort_devices_by_name(identified_devices)
+        devices = _sort_devices_by_name(connected_devices.identified_devices)
 
     output_builders = {
         "table": _build_tabular_output,

--- a/mbed_devices/_internal/mbed_tools/list_connected_devices.py
+++ b/mbed_devices/_internal/mbed_tools/list_connected_devices.py
@@ -29,9 +29,9 @@ def list_connected_devices(format: str, show_all: bool) -> None:
     connected_devices = get_connected_devices()
 
     if show_all:
-        devices = _sort_devices_by_name(connected_devices.identified_devices + connected_devices.unidentified_devices)
+        devices = _sort_devices(connected_devices.identified_devices + connected_devices.unidentified_devices)
     else:
-        devices = _sort_devices_by_name(connected_devices.identified_devices)
+        devices = _sort_devices(connected_devices.identified_devices)
 
     output_builders = {
         "table": _build_tabular_output,
@@ -44,7 +44,7 @@ def list_connected_devices(format: str, show_all: bool) -> None:
         click.echo("No connected Mbed devices found.")
 
 
-def _sort_devices_by_name(devices: Iterable[Device]) -> Iterable[Device]:
+def _sort_devices(devices: Iterable[Device]) -> Iterable[Device]:
     """Sort devices by board name and then serial number (in case there are multiple boards with the same name)."""
     return sorted(devices, key=attrgetter("mbed_target.board_name", "serial_number"))
 

--- a/mbed_devices/_internal/resolve_target.py
+++ b/mbed_devices/_internal/resolve_target.py
@@ -99,7 +99,7 @@ def _get_all_htm_files_contents(directories: Iterable[pathlib.Path]) -> List[str
 
 
 def _is_htm_file(file: pathlib.Path) -> bool:
-    """Checks whether the file looks like an Mbed HTM file.
+    """Checks whether the file looks like an Mbed HTM file and is accessible.
 
     Note that if the file is manually manipulated the file may sometimes appears to be present but not be accessible.
     """

--- a/mbed_devices/_internal/resolve_target.py
+++ b/mbed_devices/_internal/resolve_target.py
@@ -84,5 +84,9 @@ def _get_all_htm_files_contents(directories: Iterable[pathlib.Path]) -> List[str
 
 
 def _is_htm_file(file: pathlib.Path) -> bool:
+    """Checks whether the file looks like an Mbed HTM file.
+
+    Note that if the file is manually manipulated the file may sometimes appears to be present but not be accessible.
+    """
     extensions = [".htm", ".HTM"]
-    return file.suffix in extensions and not file.name.startswith(".")
+    return file.suffix in extensions and not file.name.startswith(".") and os.access(file, os.R_OK)

--- a/mbed_devices/_internal/resolve_target.py
+++ b/mbed_devices/_internal/resolve_target.py
@@ -57,7 +57,7 @@ def resolve_target(candidate: CandidateDevice) -> MbedTarget:
         try:
             return get_target_by_online_id(slug=slug, target_type=target_type)
         except UnknownTarget:
-            logger.error(f"Could not identify an Mbed Target with the Slug: '{slug}' and Target Type '{target_type}'.")
+            logger.error(f"Could not identify an Mbed Target with the Slug: '{slug}' and Target Type: '{target_type}'.")
             raise NoTargetForCandidate
 
     # Product code might be the first 4 characters of the serial number

--- a/mbed_devices/device.py
+++ b/mbed_devices/device.py
@@ -49,11 +49,11 @@ class ConnectedDevices:
     unidentified_devices: List[Device] = field(default_factory=list)
 
     def add_device(self, candidate_device: CandidateDevice, mbed_target: Optional[MbedTarget] = None) -> None:
-        """Add a candidate device and optionally an Mbed Target Construct to the connected devices.
+        """Add a candidate device and optionally an Mbed Target to the connected devices.
 
         Args:
-            candidate_device: a CandidateDevice object containing the raw information for the target.
-            mbed_target: an MbedTarget object for identified devices, for unidentified devices this may be None.
+            candidate_device: a CandidateDevice object containing the device information.
+            mbed_target: an MbedTarget object for identified devices, for unidentified devices this will be None.
         """
         new_device = Device(
             serial_port=candidate_device.serial_port,

--- a/mbed_devices/device.py
+++ b/mbed_devices/device.py
@@ -48,7 +48,7 @@ class ConnectedDevices:
     identified_devices: List[Device] = field(default_factory=list)
     unidentified_devices: List[Device] = field(default_factory=list)
 
-    def add_device(self, candidate_device: CandidateDevice, mbed_target: Optional[MbedTarget] = None):
+    def add_device(self, candidate_device: CandidateDevice, mbed_target: Optional[MbedTarget] = None) -> None:
         """Add a candidate device and optionally an Mbed Target Construct to the connected devices.
 
         Args:

--- a/mbed_devices/device.py
+++ b/mbed_devices/device.py
@@ -2,10 +2,10 @@
 # Copyright (C) 2020 Arm Mbed. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-"""Device data model definition."""
-from dataclasses import dataclass
+"""Data model definition for Device and ConnectedDevices."""
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 from mbed_targets import MbedTarget
 
 
@@ -27,3 +27,22 @@ class Device:
     serial_number: str
     serial_port: Optional[str]
     mount_points: Tuple[Path, ...]
+
+
+@dataclass(order=True)
+class ConnectedDevices:
+    """Definition of connected devices which may be Mbed Targets.
+
+    If a connected device is identified as an Mbed Target by using the HTM file on the USB mass storage device (or
+    sometimes by using the serial number), it will be included in the `identified_devices` list.
+
+    However, if the device appears as if it could be an Mbed Target but it has not been possible to find a matching
+    entry in the database then it will be included in the `unidentified_devices` list.
+
+    Attributes:
+        identified_devices: A list of devices that have been identified as MbedTargets.
+        unidentified_devices: A list of devices that could potentially be MbedTargets.
+    """
+
+    identified_devices: List[Device] = field(default_factory=list)
+    unidentified_devices: List[Device] = field(default_factory=list)

--- a/mbed_devices/mbed_devices.py
+++ b/mbed_devices/mbed_devices.py
@@ -6,12 +6,11 @@
 
 from mbed_targets.exceptions import MbedTargetsError
 
-from mbed_devices._internal.detect_candidate_devices import CandidateDevice, detect_candidate_devices
+from mbed_devices._internal.detect_candidate_devices import detect_candidate_devices
 from mbed_devices._internal.resolve_target import resolve_target
 from mbed_devices._internal.exceptions import NoTargetForCandidate
 
-from mbed_targets import MbedTarget
-from mbed_devices.device import Device, ConnectedDevices
+from mbed_devices.device import ConnectedDevices
 from mbed_devices.exceptions import DeviceLookupFailed
 
 
@@ -29,25 +28,11 @@ def get_connected_devices() -> ConnectedDevices:
     for candidate_device in detect_candidate_devices():
         try:
             mbed_target = resolve_target(candidate_device)
+        except NoTargetForCandidate:
+            mbed_target = None
         except MbedTargetsError as err:
             raise DeviceLookupFailed("A problem occurred when looking up Mbed Targets for connected devices.") from err
-        except NoTargetForCandidate:
-            # Empty Mbed Target to ensure rendering is simple
-            mbed_target = MbedTarget.from_offline_target_entry({})
-            # Keep a list of devices that could not be identified but are Mbed Targets
-            connected_devices.unidentified_devices.append(_build_device(candidate_device, mbed_target))
-        else:
-            # Keep a list of devices that have been identified as Mbed Targets
-            connected_devices.identified_devices.append(_build_device(candidate_device, mbed_target))
+
+        connected_devices.add_device(candidate_device, mbed_target)
 
     return connected_devices
-
-
-def _build_device(candidate_device: CandidateDevice, mbed_target: MbedTarget) -> Device:
-    """Construct a device instance from a candidate device and Mbed Target."""
-    return Device(
-        serial_port=candidate_device.serial_port,
-        serial_number=candidate_device.serial_number,
-        mount_points=candidate_device.mount_points,
-        mbed_target=mbed_target,
-    )

--- a/mbed_devices/mbed_devices.py
+++ b/mbed_devices/mbed_devices.py
@@ -3,37 +3,53 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 """API for listing devices."""
-from typing import Iterable
+from typing import Tuple, List
 
 from mbed_targets.exceptions import MbedTargetsError
 
-from mbed_devices._internal.candidate_device import CandidateDevice
-from mbed_devices._internal.detect_candidate_devices import detect_candidate_devices
+from mbed_devices._internal.detect_candidate_devices import CandidateDevice, detect_candidate_devices
 from mbed_devices._internal.resolve_target import resolve_target
 from mbed_devices._internal.exceptions import NoTargetForCandidate
 
+from mbed_targets import MbedTarget
 from mbed_devices.device import Device
 from mbed_devices.exceptions import DeviceLookupFailed
 
 
-def get_connected_devices() -> Iterable[Device]:
-    """Returns Mbed Devices connected to host computer."""
-    devices = []
+def get_connected_devices() -> Tuple[List[Device], List[Device]]:
+    """Returns Mbed Devices connected to host computer.
+
+    Returns:
+        A tuple containing two lists, the first containing devices identified as Mbed Targets the second those devices
+        connected but not identified as Mbed Targets.
+
+    Raises:
+        DeviceLookupFailed: TODO: find out when.
+    """
+    identified_devices = []
+    unidentified_devices = []
     for candidate_device in detect_candidate_devices():
         try:
-            devices.append(_build_device(candidate_device))
+            mbed_target = resolve_target(candidate_device)
+        except MbedTargetsError as err:
+            raise DeviceLookupFailed("A problem occurred when looking up Mbed Targets for connected devices.") from err
         except NoTargetForCandidate:
-            pass
-    return devices
+            # Empty Mbed Target to ensure rendering is simple
+            mbed_target = MbedTarget.from_offline_target_entry({})
+            # Keep a list of devices that could not be identified but are Mbed Targets
+            unidentified_devices.append(_build_device(candidate_device, mbed_target))
+        else:
+            # Keep a list of devices that have been identified as Mbed Targets
+            identified_devices.append(_build_device(candidate_device, mbed_target))
+
+    return identified_devices, unidentified_devices
 
 
-def _build_device(candidate: CandidateDevice) -> Device:
-    try:
-        return Device(
-            serial_port=candidate.serial_port,
-            serial_number=candidate.serial_number,
-            mount_points=candidate.mount_points,
-            mbed_target=resolve_target(candidate),
-        )
-    except MbedTargetsError as err:
-        raise DeviceLookupFailed("Failed to find a connected device.") from err
+def _build_device(candidate_device: CandidateDevice, mbed_target: MbedTarget) -> Device:
+    """Construct a device instance from a candidate device and Mbed Target."""
+    return Device(
+        serial_port=candidate_device.serial_port,
+        serial_number=candidate_device.serial_number,
+        mount_points=candidate_device.mount_points,
+        mbed_target=mbed_target,
+    )

--- a/news/20200401.feature
+++ b/news/20200401.feature
@@ -1,0 +1,1 @@
+Added new command line option `--show-all` to display connected devices and improved log messages.

--- a/tests/_internal/mbed_tools/test_list_connected_devices.py
+++ b/tests/_internal/mbed_tools/test_list_connected_devices.py
@@ -15,7 +15,7 @@ from mbed_devices._internal.mbed_tools.list_connected_devices import (
     _build_tabular_output,
     _build_json_output,
     _get_build_targets,
-    _sort_devices_by_name,
+    _sort_devices,
 )
 from mbed_devices import Device
 
@@ -30,10 +30,10 @@ class TestListConnectedDevices(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn("No connected Mbed devices found.", result.output)
 
-    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
+    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices")
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_tabular_output")
     def test_by_default_lists_devices_using_tabular_output(
-        self, _build_tabular_output, _sort_devices_by_name, get_connected_devices
+        self, _build_tabular_output, _sort_devices, get_connected_devices
     ):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
@@ -46,13 +46,13 @@ class TestListConnectedDevices(TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn(_build_tabular_output.return_value, result.output)
-        _build_tabular_output.assert_called_once_with(_sort_devices_by_name.return_value)
-        _sort_devices_by_name.assert_called_once_with(identified_devices)
+        _build_tabular_output.assert_called_once_with(_sort_devices.return_value)
+        _sort_devices.assert_called_once_with(identified_devices)
 
-    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
+    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices")
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_json_output")
     def test_given_json_flag_lists_devices_using_json_output(
-        self, _build_json_output, _sort_devices_by_name, get_connected_devices
+        self, _build_json_output, _sort_devices, get_connected_devices
     ):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
@@ -65,12 +65,12 @@ class TestListConnectedDevices(TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn(_build_json_output.return_value, result.output)
-        _build_json_output.assert_called_once_with(_sort_devices_by_name.return_value)
-        _sort_devices_by_name.assert_called_once_with(identified_devices)
+        _build_json_output.assert_called_once_with(_sort_devices.return_value)
+        _sort_devices.assert_called_once_with(identified_devices)
 
-    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
+    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices")
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_tabular_output")
-    def test_given_show_all(self, _build_tabular_output, _sort_devices_by_name, get_connected_devices):
+    def test_given_show_all(self, _build_tabular_output, _sort_devices, get_connected_devices):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
         get_connected_devices.return_value = ConnectedDevices(
@@ -82,11 +82,11 @@ class TestListConnectedDevices(TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn(_build_tabular_output.return_value, result.output)
-        _build_tabular_output.assert_called_once_with(_sort_devices_by_name.return_value)
-        _sort_devices_by_name.assert_called_once_with(identified_devices + unidentified_devices)
+        _build_tabular_output.assert_called_once_with(_sort_devices.return_value)
+        _sort_devices.assert_called_once_with(identified_devices + unidentified_devices)
 
 
-class TestSortDevicesByName(TestCase):
+class TestSortDevices(TestCase):
     def test_sorts_devices_by_mbed_target_board_name(self):
         device_1 = mock.create_autospec(
             Device, mbed_target=mock.create_autospec(MbedTarget, board_name="A"), serial_number="123"
@@ -98,7 +98,7 @@ class TestSortDevicesByName(TestCase):
             Device, mbed_target=mock.create_autospec(MbedTarget, board_name="C"), serial_number="789"
         )
 
-        result = _sort_devices_by_name([device_3, device_1, device_2])
+        result = _sort_devices([device_3, device_1, device_2])
 
         self.assertEqual(list(result), [device_1, device_2, device_3])
 
@@ -113,7 +113,7 @@ class TestSortDevicesByName(TestCase):
             Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="789"
         )
 
-        result = _sort_devices_by_name([device_3, device_1, device_2])
+        result = _sort_devices([device_3, device_1, device_2])
 
         self.assertEqual(list(result), [device_1, device_2, device_3])
 
@@ -128,7 +128,7 @@ class TestSortDevicesByName(TestCase):
             Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="789"
         )
 
-        result = _sort_devices_by_name([device_3, device_1, device_2])
+        result = _sort_devices([device_3, device_1, device_2])
 
         self.assertEqual(list(result), [device_1, device_3, device_2])
 

--- a/tests/_internal/mbed_tools/test_list_connected_devices.py
+++ b/tests/_internal/mbed_tools/test_list_connected_devices.py
@@ -5,6 +5,7 @@
 import json
 import pathlib
 from click.testing import CliRunner
+from mbed_devices.device import ConnectedDevices
 from mbed_targets import MbedTarget
 from tabulate import tabulate
 from unittest import TestCase, mock
@@ -22,7 +23,7 @@ from mbed_devices import Device
 @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices.get_connected_devices")
 class TestListConnectedDevices(TestCase):
     def test_informs_when_no_devices_are_connected(self, get_connected_devices):
-        get_connected_devices.return_value = [], []
+        get_connected_devices.return_value = ConnectedDevices()
 
         result = CliRunner().invoke(list_connected_devices)
 
@@ -36,7 +37,9 @@ class TestListConnectedDevices(TestCase):
     ):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
-        get_connected_devices.return_value = identified_devices, unidentified_devices
+        get_connected_devices.return_value = ConnectedDevices(
+            identified_devices=identified_devices, unidentified_devices=unidentified_devices
+        )
         _build_tabular_output.return_value = "some output"
 
         result = CliRunner().invoke(list_connected_devices)
@@ -53,7 +56,9 @@ class TestListConnectedDevices(TestCase):
     ):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
-        get_connected_devices.return_value = identified_devices, unidentified_devices
+        get_connected_devices.return_value = ConnectedDevices(
+            identified_devices=identified_devices, unidentified_devices=unidentified_devices
+        )
         _build_json_output.return_value = "some output"
 
         result = CliRunner().invoke(list_connected_devices, "--format=json")
@@ -65,12 +70,12 @@ class TestListConnectedDevices(TestCase):
 
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_tabular_output")
-    def test_given_show_all(
-        self, _build_tabular_output, _sort_devices_by_name, get_connected_devices
-    ):
+    def test_given_show_all(self, _build_tabular_output, _sort_devices_by_name, get_connected_devices):
         identified_devices = [mock.Mock(spec_set=Device)]
         unidentified_devices = [mock.Mock(spec_set=Device)]
-        get_connected_devices.return_value = identified_devices, unidentified_devices
+        get_connected_devices.return_value = ConnectedDevices(
+            identified_devices=identified_devices, unidentified_devices=unidentified_devices
+        )
         _build_tabular_output.return_value = "some output"
 
         result = CliRunner().invoke(list_connected_devices, "--show-all")

--- a/tests/_internal/mbed_tools/test_list_connected_devices.py
+++ b/tests/_internal/mbed_tools/test_list_connected_devices.py
@@ -22,7 +22,7 @@ from mbed_devices import Device
 @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices.get_connected_devices")
 class TestListConnectedDevices(TestCase):
     def test_informs_when_no_devices_are_connected(self, get_connected_devices):
-        get_connected_devices.return_value = []
+        get_connected_devices.return_value = [], []
 
         result = CliRunner().invoke(list_connected_devices)
 
@@ -34,7 +34,9 @@ class TestListConnectedDevices(TestCase):
     def test_by_default_lists_devices_using_tabular_output(
         self, _build_tabular_output, _sort_devices_by_name, get_connected_devices
     ):
-        get_connected_devices.return_value = [mock.Mock(spec_set=Device)]
+        identified_devices = [mock.Mock(spec_set=Device)]
+        unidentified_devices = [mock.Mock(spec_set=Device)]
+        get_connected_devices.return_value = identified_devices, unidentified_devices
         _build_tabular_output.return_value = "some output"
 
         result = CliRunner().invoke(list_connected_devices)
@@ -42,14 +44,16 @@ class TestListConnectedDevices(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn(_build_tabular_output.return_value, result.output)
         _build_tabular_output.assert_called_once_with(_sort_devices_by_name.return_value)
-        _sort_devices_by_name.assert_called_once_with(get_connected_devices.return_value)
+        _sort_devices_by_name.assert_called_once_with(identified_devices)
 
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
     @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_json_output")
     def test_given_json_flag_lists_devices_using_json_output(
         self, _build_json_output, _sort_devices_by_name, get_connected_devices
     ):
-        get_connected_devices.return_value = [mock.Mock(spec_set=Device)]
+        identified_devices = [mock.Mock(spec_set=Device)]
+        unidentified_devices = [mock.Mock(spec_set=Device)]
+        get_connected_devices.return_value = identified_devices, unidentified_devices
         _build_json_output.return_value = "some output"
 
         result = CliRunner().invoke(list_connected_devices, "--format=json")
@@ -57,18 +61,71 @@ class TestListConnectedDevices(TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIn(_build_json_output.return_value, result.output)
         _build_json_output.assert_called_once_with(_sort_devices_by_name.return_value)
-        _sort_devices_by_name.assert_called_once_with(get_connected_devices.return_value)
+        _sort_devices_by_name.assert_called_once_with(identified_devices)
+
+    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._sort_devices_by_name")
+    @mock.patch("mbed_devices._internal.mbed_tools.list_connected_devices._build_tabular_output")
+    def test_given_show_all(
+        self, _build_tabular_output, _sort_devices_by_name, get_connected_devices
+    ):
+        identified_devices = [mock.Mock(spec_set=Device)]
+        unidentified_devices = [mock.Mock(spec_set=Device)]
+        get_connected_devices.return_value = identified_devices, unidentified_devices
+        _build_tabular_output.return_value = "some output"
+
+        result = CliRunner().invoke(list_connected_devices, "--show-all")
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(_build_tabular_output.return_value, result.output)
+        _build_tabular_output.assert_called_once_with(_sort_devices_by_name.return_value)
+        _sort_devices_by_name.assert_called_once_with(identified_devices + unidentified_devices)
 
 
 class TestSortDevicesByName(TestCase):
     def test_sorts_devices_by_mbed_target_board_name(self):
-        device_1 = mock.create_autospec(Device, mbed_target=mock.create_autospec(MbedTarget, board_name="A"))
-        device_2 = mock.create_autospec(Device, mbed_target=mock.create_autospec(MbedTarget, board_name="B"))
-        device_3 = mock.create_autospec(Device, mbed_target=mock.create_autospec(MbedTarget, board_name="C"))
+        device_1 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name="A"), serial_number="123"
+        )
+        device_2 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name="B"), serial_number="456"
+        )
+        device_3 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name="C"), serial_number="789"
+        )
 
         result = _sort_devices_by_name([device_3, device_1, device_2])
 
         self.assertEqual(list(result), [device_1, device_2, device_3])
+
+    def test_sorts_devices_by_serial_number(self):
+        device_1 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="123"
+        )
+        device_2 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="456"
+        )
+        device_3 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="789"
+        )
+
+        result = _sort_devices_by_name([device_3, device_1, device_2])
+
+        self.assertEqual(list(result), [device_1, device_2, device_3])
+
+    def test_sorts_devices_by_board_name_then_serial_number(self):
+        device_1 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="123"
+        )
+        device_2 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name="Mbed"), serial_number="456"
+        )
+        device_3 = mock.create_autospec(
+            Device, mbed_target=mock.create_autospec(MbedTarget, board_name=""), serial_number="789"
+        )
+
+        result = _sort_devices_by_name([device_3, device_1, device_2])
+
+        self.assertEqual(list(result), [device_1, device_3, device_2])
 
 
 class TestBuildTableOutput(TestCase):

--- a/tests/_internal/test_htm_file.py
+++ b/tests/_internal/test_htm_file.py
@@ -32,9 +32,7 @@ class TestReadOnlineId(TestCase):
         url = "https://os.mbed.com/platforms/THIS-IS_a_SLUG_123/"
         file_contents = f"window.location.replace({url});"
 
-        self.assertEqual(
-            read_online_id(file_contents), OnlineId(device_type="platform", device_slug="THIS-IS_a_SLUG_123")
-        )
+        self.assertEqual(read_online_id(file_contents), OnlineId(target_type="platform", slug="THIS-IS_a_SLUG_123"))
 
     def test_none_if_not_found(self):
         file_contents = f"window.location.replace(https://os.mbed.com/about);"

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -13,6 +13,7 @@ from mbed_devices._internal.resolve_target import (
     NoTargetForCandidate,
     _get_all_htm_files_contents,
     resolve_target,
+    _read_htm_file_contents,
     _is_htm_file,
 )
 
@@ -122,6 +123,16 @@ class TestGetAllHtmFilesContents(TestCase):
         self.assertEqual(result, ["foo", "bar"])
 
 
+class TestReadHtmFilesContents(TestCase):
+    def test_handles_unreadable_htm_file(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file("mbed.htm", contents="foo")
+
+            result = _read_htm_file_contents([pathlib.Path("mbed.htm"), pathlib.Path("error.htm")])
+
+        self.assertEqual(result, ["foo"])
+
+
 class TestIsHtmFile(TestCase):
     def test_lower_case_htm(self):
         with Patcher() as patcher:
@@ -148,11 +159,5 @@ class TestIsHtmFile(TestCase):
         with Patcher() as patcher:
             patcher.fs.create_file("mbed.txt", contents="foo")
             result = _is_htm_file(pathlib.Path("mbed.txt"))
-
-        self.assertEqual(False, result)
-
-    def test_unaccessible_file_htm(self):
-        # This should not be considered a valid file as this will raise an exception if accessed
-        result = _is_htm_file(pathlib.Path("mbed.htm"))
 
         self.assertEqual(False, result)

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -58,7 +58,7 @@ class TestResolveTargetUsingOnlineIdFromHTM(TestCase):
     def test_returns_resolved_target(
         self, get_target_by_online_id, read_online_id, read_product_code, _get_all_htm_files_contents
     ):
-        online_id = OnlineId(device_type="hat", device_slug="boat")
+        online_id = OnlineId(target_type="hat", slug="boat")
         read_online_id.return_value = online_id
         candidate = CandidateDeviceFactory()
 
@@ -66,12 +66,12 @@ class TestResolveTargetUsingOnlineIdFromHTM(TestCase):
 
         self.assertEqual(subject, get_target_by_online_id.return_value)
         read_online_id.assert_called_with(_get_all_htm_files_contents.return_value[0])
-        get_target_by_online_id.assert_called_once_with(slug=online_id.device_slug, target_type=online_id.device_type)
+        get_target_by_online_id.assert_called_once_with(target_type=online_id.target_type, slug=online_id.slug)
 
     def test_raises_when_target_not_found(
         self, get_target_by_online_id, read_online_id, read_product_code, _get_all_htm_files_contents
     ):
-        read_online_id.return_value = OnlineId(device_type="hat", device_slug="boat")
+        read_online_id.return_value = OnlineId(target_type="hat", slug="boat")
         get_target_by_online_id.side_effect = UnknownTarget
         candidate = CandidateDeviceFactory()
 

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -13,6 +13,7 @@ from mbed_devices._internal.resolve_target import (
     NoTargetForCandidate,
     _get_all_htm_files_contents,
     resolve_target,
+    _is_htm_file,
 )
 
 
@@ -119,3 +120,39 @@ class TestGetAllHtmFilesContents(TestCase):
             result = _get_all_htm_files_contents([pathlib.Path("/test-1"), pathlib.Path("/test-2")])
 
         self.assertEqual(result, ["foo", "bar"])
+
+
+class TestIsHtmFile(TestCase):
+    def test_lower_case_htm(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file("mbed.htm", contents="foo")
+            result = _is_htm_file(pathlib.Path("mbed.htm"))
+
+        self.assertEqual(True, result)
+
+    def test_upper_case_htm(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file("MBED.HTM", contents="foo")
+            result = _is_htm_file(pathlib.Path("MBED.HTM"))
+
+        self.assertEqual(True, result)
+
+    def test_hidden_htm(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file(".htm", contents="foo")
+            result = _is_htm_file(pathlib.Path(".htm"))
+
+        self.assertEqual(False, result)
+
+    def test_text_file(self):
+        with Patcher() as patcher:
+            patcher.fs.create_file("mbed.txt", contents="foo")
+            result = _is_htm_file(pathlib.Path("mbed.txt"))
+
+        self.assertEqual(False, result)
+
+    def test_unaccessible_file_htm(self):
+        # This should not be considered a valid file as this will raise an exception if accessed
+        result = _is_htm_file(pathlib.Path("mbed.htm"))
+
+        self.assertEqual(False, result)

--- a/tests/_internal/test_resolve_target.py
+++ b/tests/_internal/test_resolve_target.py
@@ -135,29 +135,17 @@ class TestReadHtmFilesContents(TestCase):
 
 class TestIsHtmFile(TestCase):
     def test_lower_case_htm(self):
-        with Patcher() as patcher:
-            patcher.fs.create_file("mbed.htm", contents="foo")
-            result = _is_htm_file(pathlib.Path("mbed.htm"))
-
+        result = _is_htm_file(pathlib.Path("mbed.htm"))
         self.assertEqual(True, result)
 
     def test_upper_case_htm(self):
-        with Patcher() as patcher:
-            patcher.fs.create_file("MBED.HTM", contents="foo")
-            result = _is_htm_file(pathlib.Path("MBED.HTM"))
-
+        result = _is_htm_file(pathlib.Path("MBED.HTM"))
         self.assertEqual(True, result)
 
     def test_hidden_htm(self):
-        with Patcher() as patcher:
-            patcher.fs.create_file(".htm", contents="foo")
-            result = _is_htm_file(pathlib.Path(".htm"))
-
+        result = _is_htm_file(pathlib.Path(".htm"))
         self.assertEqual(False, result)
 
     def test_text_file(self):
-        with Patcher() as patcher:
-            patcher.fs.create_file("mbed.txt", contents="foo")
-            result = _is_htm_file(pathlib.Path("mbed.txt"))
-
+        result = _is_htm_file(pathlib.Path("mbed.txt"))
         self.assertEqual(False, result)

--- a/tests/test_mbed_devices.py
+++ b/tests/test_mbed_devices.py
@@ -4,6 +4,7 @@
 #
 from unittest import TestCase, mock
 
+from mbed_targets import MbedTarget
 from mbed_targets.exceptions import MbedTargetsError
 
 from tests.factories import CandidateDeviceFactory
@@ -20,8 +21,10 @@ class TestGetConnectedDevices(TestCase):
     def test_builds_devices_from_candidates(self, resolve_target, detect_candidate_devices):
         candidate = CandidateDeviceFactory()
         detect_candidate_devices.return_value = [candidate]
+
+        identified_devices, unidentified_devices = get_connected_devices()
         self.assertEqual(
-            get_connected_devices(),
+            identified_devices,
             [
                 Device(
                     serial_port=candidate.serial_port,
@@ -31,13 +34,29 @@ class TestGetConnectedDevices(TestCase):
                 )
             ],
         )
+        self.assertEqual(unidentified_devices, [])
         resolve_target.assert_called_once_with(candidate)
 
-    def test_skips_candidates_without_a_target(self, resolve_target, detect_candidate_devices):
+    @mock.patch.object(MbedTarget, "from_offline_target_entry")
+    def test_skips_candidates_without_a_target(self, mbed_target, resolve_target, detect_candidate_devices):
         candidate = CandidateDeviceFactory()
         resolve_target.side_effect = NoTargetForCandidate
         detect_candidate_devices.return_value = [candidate]
-        self.assertEqual(get_connected_devices(), [])
+        mbed_target.return_value = None
+
+        identified_devices, unidentified_devices = get_connected_devices()
+        self.assertEqual(identified_devices, [])
+        self.assertEqual(
+            unidentified_devices,
+            [
+                Device(
+                    serial_port=candidate.serial_port,
+                    serial_number=candidate.serial_number,
+                    mount_points=candidate.mount_points,
+                    mbed_target=None,
+                )
+            ],
+        )
 
     def test_raises_device_lookup_failed_on_internal_error(self, resolve_target, detect_candidate_devices):
         resolve_target.side_effect = MbedTargetsError

--- a/tests/test_mbed_devices.py
+++ b/tests/test_mbed_devices.py
@@ -22,9 +22,9 @@ class TestGetConnectedDevices(TestCase):
         candidate = CandidateDeviceFactory()
         detect_candidate_devices.return_value = [candidate]
 
-        identified_devices, unidentified_devices = get_connected_devices()
+        connected_devices = get_connected_devices()
         self.assertEqual(
-            identified_devices,
+            connected_devices.identified_devices,
             [
                 Device(
                     serial_port=candidate.serial_port,
@@ -34,7 +34,7 @@ class TestGetConnectedDevices(TestCase):
                 )
             ],
         )
-        self.assertEqual(unidentified_devices, [])
+        self.assertEqual(connected_devices.unidentified_devices, [])
         resolve_target.assert_called_once_with(candidate)
 
     @mock.patch.object(MbedTarget, "from_offline_target_entry")
@@ -44,10 +44,10 @@ class TestGetConnectedDevices(TestCase):
         detect_candidate_devices.return_value = [candidate]
         mbed_target.return_value = None
 
-        identified_devices, unidentified_devices = get_connected_devices()
-        self.assertEqual(identified_devices, [])
+        connected_devices = get_connected_devices()
+        self.assertEqual(connected_devices.identified_devices, [])
         self.assertEqual(
-            unidentified_devices,
+            connected_devices.unidentified_devices,
             [
                 Device(
                     serial_port=candidate.serial_port,


### PR DESCRIPTION
### Description

- Keep track of devices which could not be identified
- Add command line option to show all connected devices
- Generate log messages when targets cannot be identified
- Rename OnlineId attributes to match online database and API
- Fixed minor bug with HTM file reading

### Test Coverage

<!--
Please put an `x` in the correct box e.g. `[x]` to indicate the testing coverage of this change.
-->

- [x]  This change is covered by existing or additional automated tests.
- [x]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).

### Manual Test Output

#### Problem connecting the online database

Auto mode:

```
▶ mbed-tools devices
ERROR: A problem occurred when looking up Mbed Targets for connected devices.
Increase the verbosity level to `-vvv` to see debug information. Use the `--traceback` argument to see a full stack trace.

▶ mbed-tools -v devices
WARNING: There was an error connecting to the online database. Please check your internet connection.
ERROR: A problem occurred when looking up Mbed Targets for connected devices.
Increase the verbosity level to `-vvv` to see debug information. Use the `--traceback` argument to see a full stack trace.

▶ mbed-tools -vv devices
INFO: Using the online database to identify Mbed Targets.
INFO: Unable to identify an Mbed Target using the offline database, trying the online database.
WARNING: There was an error connecting to the online database. Please check your internet connection.
ERROR: A problem occurred when looking up Mbed Targets for connected devices.
Increase the verbosity level to `-vvv` to see debug information. Use the `--traceback` argument to see a full stack trace.
```

Online Mode:

```
▶ mbed-tools devices
ERROR: A problem occurred when looking up Mbed Targets for connected devices.
Increase the verbosity level to `-vvv` to see debug information. Use the `--traceback` argument to see a full stack trace.

▶ mbed-tools -v devices
WARNING: There was an error connecting to the online database. Please check your internet connection.
ERROR: A problem occurred when looking up Mbed Targets for connected devices.
Increase the verbosity level to `-vvv` to see debug information. Use the `--traceback` argument to see a full stack trace.

▶ mbed-tools -vv devices
INFO: Using the online database (only) to identify Mbed Targets.
WARNING: There was an error connecting to the online database. Please check your internet connection.
ERROR: A problem occurred when looking up Mbed Targets for connected devices.

```

#### Device connected has a serial number which does not match a known Mbed Target (offline)

Standard:

```
▶ mbed-tools devices
No connected Mbed devices found.
```

Show all selected:

```
▶ mbed-tools devices --show-all
Board name    Serial number             Serial port             Mount point(s)    Build target(s)
------------  ------------------------  ----------------------  ----------------  -----------------
              02400201CCF63E703108C3C8  /dev/tty.usbmodem14202  /Volumes/MBED
```

Show all selected and verbose mode:

```
▶ mbed-tools -vv devices --show-all
INFO: Using the offline database (only) to identify Mbed Targets.
INFO: The device with the Serial Number: '02400201CCF63E703108C3C8' (Product Code: '0240') does not appear to be an Mbed Target .
Board name    Serial number             Serial port             Mount point(s)    Build target(s)
------------  ------------------------  ----------------------  ----------------  -----------------
              02400201CCF63E703108C3C8  /dev/tty.usbmodem14202  /Volumes/MBED
```

#### Device with the product code in the HTM file but no match (auto)

```
▶ mbed-tools devices
ERROR: Could not identify an Mbed Target with the Product Code: '0000'.
No connected Mbed devices found.

▶ mbed-tools -vv devices
INFO: Using the online database to identify Mbed Targets.
INFO: Unable to identify an Mbed Target using the offline database, trying the online database.
ERROR: Could not identify an Mbed Target with the Product Code: '0000'.
No connected Mbed devices found.
```

#### Device with a slug ande device type in the HTM file but no match (auto)

```
▶ mbed-tools -vv devices
▶ mbed-tools devices
ERROR: Could not identify an Mbed Target with the Slug: 'badger' and Target Type 'module'.
No connected Mbed devices found.

▶ mbed-tools -vv devices
INFO: Using the online database to identify Mbed Targets.
INFO: Unable to identify an Mbed Target using the offline database, trying the online database.
ERROR: Could not identify an Mbed Target with the Slug: 'badger' and Target Type 'module'.
No connected Mbed devices found.
```



